### PR TITLE
feat: Photo tracking with gallery and comparison

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -11,6 +11,7 @@ android {
     ndkVersion = flutter.ndkVersion
 
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
@@ -41,4 +42,8 @@ android {
 
 flutter {
     source = "../.."
+}
+
+dependencies {
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Camera and storage permissions for progress photos -->
+    <uses-permission android:name="android.permission.CAMERA"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-feature android:name="android.hardware.camera" android:required="false"/>
+    
     <application
         android:label="body_tracker"
         android:name="${applicationName}"

--- a/lib/models/progress_photo.dart
+++ b/lib/models/progress_photo.dart
@@ -1,0 +1,64 @@
+class ProgressPhoto {
+  final int? id;
+  final int userId;
+  final String imagePath;
+  final String? category; // front, side, back
+  final String? notes;
+  final DateTime takenAt;
+  final DateTime createdAt;
+
+  ProgressPhoto({
+    this.id,
+    required this.userId,
+    required this.imagePath,
+    this.category,
+    this.notes,
+    DateTime? takenAt,
+    DateTime? createdAt,
+  })  : takenAt = takenAt ?? DateTime.now(),
+        createdAt = createdAt ?? DateTime.now();
+
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'user_id': userId,
+      'image_path': imagePath,
+      'category': category,
+      'notes': notes,
+      'taken_at': takenAt.toIso8601String(),
+      'created_at': createdAt.toIso8601String(),
+    };
+  }
+
+  factory ProgressPhoto.fromMap(Map<String, dynamic> map) {
+    return ProgressPhoto(
+      id: map['id'] as int?,
+      userId: map['user_id'] as int,
+      imagePath: map['image_path'] as String,
+      category: map['category'] as String?,
+      notes: map['notes'] as String?,
+      takenAt: DateTime.parse(map['taken_at'] as String),
+      createdAt: DateTime.parse(map['created_at'] as String),
+    );
+  }
+
+  ProgressPhoto copyWith({
+    int? id,
+    int? userId,
+    String? imagePath,
+    String? category,
+    String? notes,
+    DateTime? takenAt,
+    DateTime? createdAt,
+  }) {
+    return ProgressPhoto(
+      id: id ?? this.id,
+      userId: userId ?? this.userId,
+      imagePath: imagePath ?? this.imagePath,
+      category: category ?? this.category,
+      notes: notes ?? this.notes,
+      takenAt: takenAt ?? this.takenAt,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+}

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -5,6 +5,7 @@ import '../../providers/app_provider.dart';
 import '../../utils/app_theme.dart';
 import '../measurements/guided_measurement_flow.dart';
 import '../measurements/measurement_input_screen.dart';
+import '../photos/photo_gallery_screen.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -24,6 +25,7 @@ class _HomeScreenState extends State<HomeScreen> {
         children: const [
           DashboardTab(),
           MeasurementsTab(),
+          PhotoGalleryScreen(),
           SizesTab(),
           ProfileTab(),
         ],
@@ -42,6 +44,7 @@ class _HomeScreenState extends State<HomeScreen> {
         child: BottomNavigationBar(
           currentIndex: _currentIndex,
           onTap: (index) => setState(() => _currentIndex = index),
+          type: BottomNavigationBarType.fixed,
           items: const [
             BottomNavigationBarItem(
               icon: Icon(Icons.dashboard_outlined),
@@ -52,6 +55,11 @@ class _HomeScreenState extends State<HomeScreen> {
               icon: Icon(Icons.straighten_outlined),
               activeIcon: Icon(Icons.straighten),
               label: 'Measure',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.photo_camera_outlined),
+              activeIcon: Icon(Icons.photo_camera),
+              label: 'Photos',
             ),
             BottomNavigationBarItem(
               icon: Icon(Icons.checkroom_outlined),

--- a/lib/screens/onboarding/onboarding_screen.dart
+++ b/lib/screens/onboarding/onboarding_screen.dart
@@ -324,10 +324,19 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
     );
   }
 
+  int? _calculateAge(DateTime? birthDate) {
+    if (birthDate == null) return null;
+    final now = DateTime.now();
+    int age = now.year - birthDate.year;
+    if (now.month < birthDate.month ||
+        (now.month == birthDate.month && now.day < birthDate.day)) {
+      age--;
+    }
+    return age;
+  }
+
   Widget _buildBirthdayPage() {
-    final age = _dateOfBirth != null
-        ? DateTime.now().year - _dateOfBirth!.year
-        : null;
+    final age = _calculateAge(_dateOfBirth);
 
     return Padding(
       padding: const EdgeInsets.all(24.0),

--- a/lib/screens/photos/photo_compare_screen.dart
+++ b/lib/screens/photos/photo_compare_screen.dart
@@ -1,0 +1,340 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import '../../models/progress_photo.dart';
+
+class PhotoCompareScreen extends StatefulWidget {
+  final List<ProgressPhoto> photos;
+
+  const PhotoCompareScreen({super.key, required this.photos});
+
+  @override
+  State<PhotoCompareScreen> createState() => _PhotoCompareScreenState();
+}
+
+class _PhotoCompareScreenState extends State<PhotoCompareScreen> {
+  late List<ProgressPhoto> _sortedPhotos;
+  int _beforeIndex = 0;
+  int _afterIndex = 1;
+  double _overlayOpacity = 0.5;
+  bool _showOverlay = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _sortedPhotos = List.from(widget.photos)
+      ..sort((a, b) => a.takenAt.compareTo(b.takenAt));
+    if (_sortedPhotos.length > 1) {
+      _beforeIndex = 0;
+      _afterIndex = _sortedPhotos.length - 1;
+    }
+  }
+
+  void _selectPhoto(bool isBefore) async {
+    final selected = await showModalBottomSheet<int>(
+      context: context,
+      isScrollControlled: true,
+      builder: (context) => DraggableScrollableSheet(
+        initialChildSize: 0.6,
+        maxChildSize: 0.9,
+        minChildSize: 0.3,
+        expand: false,
+        builder: (context, scrollController) {
+          return Column(
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: Text(
+                  isBefore ? 'Select BEFORE Photo' : 'Select AFTER Photo',
+                  style: const TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+              Expanded(
+                child: GridView.builder(
+                  controller: scrollController,
+                  padding: const EdgeInsets.all(8),
+                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: 3,
+                    crossAxisSpacing: 4,
+                    mainAxisSpacing: 4,
+                  ),
+                  itemCount: _sortedPhotos.length,
+                  itemBuilder: (context, index) {
+                    final photo = _sortedPhotos[index];
+                    final isSelected = isBefore
+                        ? index == _beforeIndex
+                        : index == _afterIndex;
+                    return GestureDetector(
+                      onTap: () => Navigator.pop(context, index),
+                      child: Stack(
+                        fit: StackFit.expand,
+                        children: [
+                          ClipRRect(
+                            borderRadius: BorderRadius.circular(8),
+                            child: Image.file(
+                              File(photo.imagePath),
+                              fit: BoxFit.cover,
+                            ),
+                          ),
+                          if (isSelected)
+                            Container(
+                              decoration: BoxDecoration(
+                                borderRadius: BorderRadius.circular(8),
+                                border: Border.all(
+                                  color: Theme.of(context).primaryColor,
+                                  width: 3,
+                                ),
+                              ),
+                            ),
+                          Positioned(
+                            bottom: 0,
+                            left: 0,
+                            right: 0,
+                            child: Container(
+                              padding: const EdgeInsets.all(4),
+                              decoration: BoxDecoration(
+                                color: Colors.black.withOpacity(0.6),
+                                borderRadius: const BorderRadius.vertical(
+                                  bottom: Radius.circular(8),
+                                ),
+                              ),
+                              child: Text(
+                                DateFormat('MMM d, y').format(photo.takenAt),
+                                style: const TextStyle(
+                                  color: Colors.white,
+                                  fontSize: 10,
+                                ),
+                                textAlign: TextAlign.center,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+
+    if (selected != null) {
+      setState(() {
+        if (isBefore) {
+          _beforeIndex = selected;
+        } else {
+          _afterIndex = selected;
+        }
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final beforePhoto = _sortedPhotos[_beforeIndex];
+    final afterPhoto = _sortedPhotos[_afterIndex];
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Compare Photos'),
+        actions: [
+          IconButton(
+            icon: Icon(_showOverlay ? Icons.layers : Icons.layers_outlined),
+            onPressed: () => setState(() => _showOverlay = !_showOverlay),
+            tooltip: 'Toggle Overlay Mode',
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: _showOverlay
+                ? _buildOverlayView(beforePhoto, afterPhoto)
+                : _buildSideBySideView(beforePhoto, afterPhoto),
+          ),
+          if (_showOverlay)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: Row(
+                children: [
+                  const Text('Before'),
+                  Expanded(
+                    child: Slider(
+                      value: _overlayOpacity,
+                      onChanged: (value) =>
+                          setState(() => _overlayOpacity = value),
+                    ),
+                  ),
+                  const Text('After'),
+                ],
+              ),
+            ),
+          SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: _buildPhotoSelector(
+                      'BEFORE',
+                      beforePhoto,
+                      () => _selectPhoto(true),
+                    ),
+                  ),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: _buildPhotoSelector(
+                      'AFTER',
+                      afterPhoto,
+                      () => _selectPhoto(false),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSideBySideView(ProgressPhoto before, ProgressPhoto after) {
+    return Row(
+      children: [
+        Expanded(
+          child: _buildPhotoPanel(before, 'BEFORE'),
+        ),
+        Container(width: 2, color: Colors.grey[800]),
+        Expanded(
+          child: _buildPhotoPanel(after, 'AFTER'),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildOverlayView(ProgressPhoto before, ProgressPhoto after) {
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        Image.file(
+          File(before.imagePath),
+          fit: BoxFit.contain,
+        ),
+        Opacity(
+          opacity: _overlayOpacity,
+          child: Image.file(
+            File(after.imagePath),
+            fit: BoxFit.contain,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildPhotoPanel(ProgressPhoto photo, String label) {
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        Image.file(
+          File(photo.imagePath),
+          fit: BoxFit.contain,
+        ),
+        Positioned(
+          top: 8,
+          left: 8,
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            decoration: BoxDecoration(
+              color: Colors.black.withOpacity(0.6),
+              borderRadius: BorderRadius.circular(4),
+            ),
+            child: Text(
+              label,
+              style: const TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.bold,
+                fontSize: 12,
+              ),
+            ),
+          ),
+        ),
+        Positioned(
+          bottom: 8,
+          left: 8,
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            decoration: BoxDecoration(
+              color: Colors.black.withOpacity(0.6),
+              borderRadius: BorderRadius.circular(4),
+            ),
+            child: Text(
+              DateFormat('MMM d, y').format(photo.takenAt),
+              style: const TextStyle(
+                color: Colors.white,
+                fontSize: 12,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildPhotoSelector(
+    String label,
+    ProgressPhoto photo,
+    VoidCallback onTap,
+  ) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.all(8),
+        decoration: BoxDecoration(
+          color: Colors.grey[900],
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(color: Colors.grey[700]!),
+        ),
+        child: Row(
+          children: [
+            ClipRRect(
+              borderRadius: BorderRadius.circular(4),
+              child: Image.file(
+                File(photo.imagePath),
+                width: 40,
+                height: 40,
+                fit: BoxFit.cover,
+              ),
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    label,
+                    style: TextStyle(
+                      fontSize: 10,
+                      color: Colors.grey[500],
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  Text(
+                    DateFormat('MMM d').format(photo.takenAt),
+                    style: const TextStyle(fontSize: 12),
+                  ),
+                ],
+              ),
+            ),
+            Icon(Icons.swap_horiz, color: Colors.grey[600], size: 20),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/photos/photo_gallery_screen.dart
+++ b/lib/screens/photos/photo_gallery_screen.dart
@@ -1,0 +1,358 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+import '../../models/progress_photo.dart';
+import '../../providers/app_provider.dart';
+import '../../services/photo_service.dart';
+import '../../utils/constants.dart';
+import 'photo_compare_screen.dart';
+import 'photo_view_screen.dart';
+
+class PhotoGalleryScreen extends StatefulWidget {
+  const PhotoGalleryScreen({super.key});
+
+  @override
+  State<PhotoGalleryScreen> createState() => _PhotoGalleryScreenState();
+}
+
+class _PhotoGalleryScreenState extends State<PhotoGalleryScreen>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+  final ImagePicker _picker = ImagePicker();
+  List<ProgressPhoto> _allPhotos = [];
+  bool _isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 4, vsync: this);
+    _loadPhotos();
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadPhotos() async {
+    final appProvider = context.read<AppProvider>();
+    final userId = appProvider.currentUser?.id;
+    if (userId == null) return;
+
+    setState(() => _isLoading = true);
+    try {
+      final photos = await PhotoService.instance.getPhotos(userId);
+      setState(() {
+        _allPhotos = photos;
+        _isLoading = false;
+      });
+    } catch (e) {
+      setState(() => _isLoading = false);
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to load photos: $e')),
+        );
+      }
+    }
+  }
+
+  List<ProgressPhoto> _getPhotosForCategory(String? category) {
+    if (category == null) return _allPhotos;
+    return _allPhotos.where((p) => p.category == category).toList();
+  }
+
+  Future<void> _takePhoto() async {
+    final source = await showModalBottomSheet<ImageSource>(
+      context: context,
+      builder: (context) => SafeArea(
+        child: Wrap(
+          children: [
+            ListTile(
+              leading: const Icon(Icons.camera_alt),
+              title: const Text('Take Photo'),
+              onTap: () => Navigator.pop(context, ImageSource.camera),
+            ),
+            ListTile(
+              leading: const Icon(Icons.photo_library),
+              title: const Text('Choose from Gallery'),
+              onTap: () => Navigator.pop(context, ImageSource.gallery),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    if (source == null) return;
+
+    try {
+      final XFile? image = await _picker.pickImage(
+        source: source,
+        maxWidth: 1920,
+        maxHeight: 1920,
+        imageQuality: 85,
+      );
+
+      if (image == null) return;
+
+      // Show category selection dialog
+      final category = await _showCategoryDialog();
+      if (category == null) return;
+
+      final appProvider = context.read<AppProvider>();
+      final userId = appProvider.currentUser?.id;
+      if (userId == null) return;
+
+      // Save the photo
+      final savedPath = await PhotoService.instance.savePhoto(
+        File(image.path),
+        category: category,
+      );
+
+      final photo = ProgressPhoto(
+        userId: userId,
+        imagePath: savedPath,
+        category: category,
+      );
+
+      await PhotoService.instance.addPhoto(photo);
+      await _loadPhotos();
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Photo saved!')),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to save photo: $e')),
+        );
+      }
+    }
+  }
+
+  Future<String?> _showCategoryDialog() async {
+    return showDialog<String>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Select Category'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: AppConstants.photoCategories.map((category) {
+            return ListTile(
+              leading: Icon(_getCategoryIcon(category)),
+              title: Text(category.toUpperCase()),
+              onTap: () => Navigator.pop(context, category),
+            );
+          }).toList(),
+        ),
+      ),
+    );
+  }
+
+  IconData _getCategoryIcon(String category) {
+    switch (category) {
+      case 'front':
+        return Icons.person;
+      case 'side':
+        return Icons.person_outline;
+      case 'back':
+        return Icons.person_off_outlined;
+      default:
+        return Icons.photo;
+    }
+  }
+
+  void _openCompare() {
+    if (_allPhotos.length < 2) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Need at least 2 photos to compare')),
+      );
+      return;
+    }
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => PhotoCompareScreen(photos: _allPhotos),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Progress Photos'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.compare),
+            onPressed: _openCompare,
+            tooltip: 'Compare Photos',
+          ),
+        ],
+        bottom: TabBar(
+          controller: _tabController,
+          tabs: const [
+            Tab(text: 'All'),
+            Tab(text: 'Front'),
+            Tab(text: 'Side'),
+            Tab(text: 'Back'),
+          ],
+        ),
+      ),
+      body: _isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : TabBarView(
+              controller: _tabController,
+              children: [
+                _buildPhotoGrid(null),
+                _buildPhotoGrid('front'),
+                _buildPhotoGrid('side'),
+                _buildPhotoGrid('back'),
+              ],
+            ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: _takePhoto,
+        icon: const Icon(Icons.camera_alt),
+        label: const Text('Add Photo'),
+      ),
+    );
+  }
+
+  Widget _buildPhotoGrid(String? category) {
+    final photos = _getPhotosForCategory(category);
+    
+    if (photos.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.photo_library_outlined,
+              size: 64,
+              color: Colors.grey[600],
+            ),
+            const SizedBox(height: 16),
+            Text(
+              category == null
+                  ? 'No photos yet'
+                  : 'No ${category.toUpperCase()} photos yet',
+              style: TextStyle(color: Colors.grey[600]),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Tap the button below to add one',
+              style: TextStyle(color: Colors.grey[700], fontSize: 12),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return GridView.builder(
+      padding: const EdgeInsets.all(8),
+      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: 3,
+        crossAxisSpacing: 4,
+        mainAxisSpacing: 4,
+      ),
+      itemCount: photos.length,
+      itemBuilder: (context, index) {
+        final photo = photos[index];
+        return _buildPhotoTile(photo);
+      },
+    );
+  }
+
+  Widget _buildPhotoTile(ProgressPhoto photo) {
+    return GestureDetector(
+      onTap: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (context) => PhotoViewScreen(
+              photo: photo,
+              onDelete: () async {
+                await PhotoService.instance.deletePhotoRecord(photo);
+                await _loadPhotos();
+              },
+            ),
+          ),
+        );
+      },
+      child: Hero(
+        tag: 'photo_${photo.id}',
+        child: Stack(
+          fit: StackFit.expand,
+          children: [
+            ClipRRect(
+              borderRadius: BorderRadius.circular(8),
+              child: Image.file(
+                File(photo.imagePath),
+                fit: BoxFit.cover,
+                errorBuilder: (context, error, stackTrace) {
+                  return Container(
+                    color: Colors.grey[800],
+                    child: const Icon(Icons.broken_image, color: Colors.grey),
+                  );
+                },
+              ),
+            ),
+            Positioned(
+              bottom: 0,
+              left: 0,
+              right: 0,
+              child: Container(
+                decoration: BoxDecoration(
+                  borderRadius: const BorderRadius.vertical(
+                    bottom: Radius.circular(8),
+                  ),
+                  gradient: LinearGradient(
+                    begin: Alignment.bottomCenter,
+                    end: Alignment.topCenter,
+                    colors: [
+                      Colors.black.withOpacity(0.7),
+                      Colors.transparent,
+                    ],
+                  ),
+                ),
+                padding: const EdgeInsets.all(4),
+                child: Text(
+                  DateFormat('MMM d').format(photo.takenAt),
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 10,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            ),
+            if (photo.category != null)
+              Positioned(
+                top: 4,
+                right: 4,
+                child: Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+                  decoration: BoxDecoration(
+                    color: Colors.black.withOpacity(0.6),
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                  child: Text(
+                    photo.category!.substring(0, 1).toUpperCase(),
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 10,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/photos/photo_view_screen.dart
+++ b/lib/screens/photos/photo_view_screen.dart
@@ -1,0 +1,148 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import '../../models/progress_photo.dart';
+
+class PhotoViewScreen extends StatelessWidget {
+  final ProgressPhoto photo;
+  final VoidCallback? onDelete;
+
+  const PhotoViewScreen({
+    super.key,
+    required this.photo,
+    this.onDelete,
+  });
+
+  void _confirmDelete(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Delete Photo'),
+        content: const Text('Are you sure you want to delete this photo?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.pop(context); // Close dialog
+              onDelete?.call();
+              Navigator.pop(context); // Return to gallery
+            },
+            style: TextButton.styleFrom(foregroundColor: Colors.red),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.black,
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        actions: [
+          if (onDelete != null)
+            IconButton(
+              icon: const Icon(Icons.delete_outline),
+              onPressed: () => _confirmDelete(context),
+            ),
+        ],
+      ),
+      extendBodyBehindAppBar: true,
+      body: Stack(
+        fit: StackFit.expand,
+        children: [
+          InteractiveViewer(
+            minScale: 0.5,
+            maxScale: 4.0,
+            child: Hero(
+              tag: 'photo_${photo.id}',
+              child: Image.file(
+                File(photo.imagePath),
+                fit: BoxFit.contain,
+                errorBuilder: (context, error, stackTrace) {
+                  return const Center(
+                    child: Icon(Icons.broken_image, color: Colors.grey, size: 64),
+                  );
+                },
+              ),
+            ),
+          ),
+          Positioned(
+            bottom: 0,
+            left: 0,
+            right: 0,
+            child: Container(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.bottomCenter,
+                  end: Alignment.topCenter,
+                  colors: [
+                    Colors.black.withOpacity(0.8),
+                    Colors.transparent,
+                  ],
+                ),
+              ),
+              padding: const EdgeInsets.all(16),
+              child: SafeArea(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Row(
+                      children: [
+                        if (photo.category != null) ...[
+                          Container(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 8,
+                              vertical: 4,
+                            ),
+                            decoration: BoxDecoration(
+                              color: Theme.of(context).primaryColor,
+                              borderRadius: BorderRadius.circular(4),
+                            ),
+                            child: Text(
+                              photo.category!.toUpperCase(),
+                              style: const TextStyle(
+                                color: Colors.white,
+                                fontSize: 12,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                          const SizedBox(width: 8),
+                        ],
+                        Text(
+                          DateFormat('EEEE, MMMM d, y').format(photo.takenAt),
+                          style: const TextStyle(
+                            color: Colors.white,
+                            fontSize: 16,
+                          ),
+                        ),
+                      ],
+                    ),
+                    if (photo.notes != null && photo.notes!.isNotEmpty) ...[
+                      const SizedBox(height: 8),
+                      Text(
+                        photo.notes!,
+                        style: TextStyle(
+                          color: Colors.white.withOpacity(0.8),
+                          fontSize: 14,
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -66,6 +66,20 @@ class DatabaseService {
       )
     ''');
 
+    // Progress photos table
+    await db.execute('''
+      CREATE TABLE progress_photos (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER NOT NULL,
+        image_path TEXT NOT NULL,
+        category TEXT,
+        notes TEXT,
+        taken_at TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+      )
+    ''');
+
     // Create indexes for better performance
     await db.execute(
         'CREATE INDEX idx_measurements_user_id ON measurements (user_id)');
@@ -73,10 +87,33 @@ class DatabaseService {
         'CREATE INDEX idx_measurements_type ON measurements (type)');
     await db.execute(
         'CREATE INDEX idx_measurements_measured_at ON measurements (measured_at)');
+    await db.execute(
+        'CREATE INDEX idx_progress_photos_user_id ON progress_photos (user_id)');
+    await db.execute(
+        'CREATE INDEX idx_progress_photos_taken_at ON progress_photos (taken_at)');
   }
 
   Future<void> _upgradeDB(Database db, int oldVersion, int newVersion) async {
     // Handle database migrations here
+    if (oldVersion < 2) {
+      // Add progress_photos table
+      await db.execute('''
+        CREATE TABLE IF NOT EXISTS progress_photos (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          user_id INTEGER NOT NULL,
+          image_path TEXT NOT NULL,
+          category TEXT,
+          notes TEXT,
+          taken_at TEXT NOT NULL,
+          created_at TEXT NOT NULL,
+          FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+        )
+      ''');
+      await db.execute(
+          'CREATE INDEX IF NOT EXISTS idx_progress_photos_user_id ON progress_photos (user_id)');
+      await db.execute(
+          'CREATE INDEX IF NOT EXISTS idx_progress_photos_taken_at ON progress_photos (taken_at)');
+    }
   }
 
   Future<void> close() async {

--- a/lib/services/photo_service.dart
+++ b/lib/services/photo_service.dart
@@ -1,0 +1,120 @@
+import 'dart:io';
+import 'package:path/path.dart' as path;
+import 'package:path_provider/path_provider.dart';
+import '../models/progress_photo.dart';
+import 'database_service.dart';
+
+class PhotoService {
+  static final PhotoService instance = PhotoService._init();
+  PhotoService._init();
+
+  /// Get the app's photo storage directory
+  Future<Directory> get _photoDirectory async {
+    final appDir = await getApplicationDocumentsDirectory();
+    final photoDir = Directory(path.join(appDir.path, 'progress_photos'));
+    if (!await photoDir.exists()) {
+      await photoDir.create(recursive: true);
+    }
+    return photoDir;
+  }
+
+  /// Save a photo to app storage and return the path
+  Future<String> savePhoto(File imageFile, {String? category}) async {
+    final photoDir = await _photoDirectory;
+    final timestamp = DateTime.now().millisecondsSinceEpoch;
+    final categoryPrefix = category ?? 'photo';
+    final extension = path.extension(imageFile.path);
+    final fileName = '${categoryPrefix}_$timestamp$extension';
+    final savedPath = path.join(photoDir.path, fileName);
+    
+    await imageFile.copy(savedPath);
+    return savedPath;
+  }
+
+  /// Delete a photo from storage
+  Future<void> deletePhoto(String imagePath) async {
+    final file = File(imagePath);
+    if (await file.exists()) {
+      await file.delete();
+    }
+  }
+
+  /// Get all photos for a user
+  Future<List<ProgressPhoto>> getPhotos(int userId) async {
+    final db = await DatabaseService.instance.database;
+    final maps = await db.query(
+      'progress_photos',
+      where: 'user_id = ?',
+      whereArgs: [userId],
+      orderBy: 'taken_at DESC',
+    );
+    return maps.map((map) => ProgressPhoto.fromMap(map)).toList();
+  }
+
+  /// Get photos by category
+  Future<List<ProgressPhoto>> getPhotosByCategory(int userId, String category) async {
+    final db = await DatabaseService.instance.database;
+    final maps = await db.query(
+      'progress_photos',
+      where: 'user_id = ? AND category = ?',
+      whereArgs: [userId, category],
+      orderBy: 'taken_at DESC',
+    );
+    return maps.map((map) => ProgressPhoto.fromMap(map)).toList();
+  }
+
+  /// Get photos within a date range
+  Future<List<ProgressPhoto>> getPhotosInRange(
+    int userId,
+    DateTime start,
+    DateTime end,
+  ) async {
+    final db = await DatabaseService.instance.database;
+    final maps = await db.query(
+      'progress_photos',
+      where: 'user_id = ? AND taken_at >= ? AND taken_at <= ?',
+      whereArgs: [userId, start.toIso8601String(), end.toIso8601String()],
+      orderBy: 'taken_at DESC',
+    );
+    return maps.map((map) => ProgressPhoto.fromMap(map)).toList();
+  }
+
+  /// Add a photo record to the database
+  Future<ProgressPhoto> addPhoto(ProgressPhoto photo) async {
+    final db = await DatabaseService.instance.database;
+    final id = await db.insert('progress_photos', photo.toMap());
+    return photo.copyWith(id: id);
+  }
+
+  /// Update a photo record
+  Future<void> updatePhoto(ProgressPhoto photo) async {
+    final db = await DatabaseService.instance.database;
+    await db.update(
+      'progress_photos',
+      photo.toMap(),
+      where: 'id = ?',
+      whereArgs: [photo.id],
+    );
+  }
+
+  /// Delete a photo record and file
+  Future<void> deletePhotoRecord(ProgressPhoto photo) async {
+    final db = await DatabaseService.instance.database;
+    await db.delete(
+      'progress_photos',
+      where: 'id = ?',
+      whereArgs: [photo.id],
+    );
+    await deletePhoto(photo.imagePath);
+  }
+
+  /// Get the count of photos for a user
+  Future<int> getPhotoCount(int userId) async {
+    final db = await DatabaseService.instance.database;
+    final result = await db.rawQuery(
+      'SELECT COUNT(*) as count FROM progress_photos WHERE user_id = ?',
+      [userId],
+    );
+    return result.first['count'] as int;
+  }
+}

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -5,7 +5,10 @@ class AppConstants {
 
   // Database
   static const String dbName = 'body_tracker.db';
-  static const int dbVersion = 1;
+  static const int dbVersion = 2;
+
+  // Photo Categories
+  static const List<String> photoCategories = ['front', 'side', 'back'];
 
   // Measurement Types
   static const List<String> measurementTypes = [

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,10 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <file_selector_linux/file_selector_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
+  file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  file_selector_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,11 +5,13 @@
 import FlutterMacOS
 import Foundation
 
+import file_selector_macos
 import flutter_local_notifications
 import shared_preferences_foundation
 import sqflite_darwin
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -41,6 +41,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
+  code_assets:
+    dependency: transitive
+    description:
+      name: code_assets
+      sha256: "83ccdaa064c980b5596c35dd64a8d3ecc68620174ab9b90b6343b753aa721687"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   collection:
     dependency: transitive
     description:
@@ -49,6 +57,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "28bb3ae56f117b5aec029d702a90f57d285cd975c3c5c281eaca38dbc47c5937"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5+2"
+  crypto:
+    dependency: transitive
+    description:
+      name: crypto
+      sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.7"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -97,6 +121,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  file_selector_linux:
+    dependency: transitive
+    description:
+      name: file_selector_linux
+      sha256: "2567f398e06ac72dcf2e98a0c95df2a9edd03c2c2e0cacd4780f20cdf56263a0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.4"
+  file_selector_macos:
+    dependency: transitive
+    description:
+      name: file_selector_macos
+      sha256: "5e0bbe9c312416f1787a68259ea1505b52f258c587f12920422671807c4d618a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.5"
+  file_selector_platform_interface:
+    dependency: transitive
+    description:
+      name: file_selector_platform_interface
+      sha256: "35e0bd61ebcdb91a3505813b055b09b79dfdc7d0aee9c09a7ba59ae4bb13dc85"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.7.0"
+  file_selector_windows:
+    dependency: transitive
+    description:
+      name: file_selector_windows
+      sha256: "62197474ae75893a62df75939c777763d39c2bc5f73ce5b88497208bc269abfd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+5"
   fl_chart:
     dependency: "direct main"
     description:
@@ -142,6 +198,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.2.0"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: ee8068e0e1cd16c4a82714119918efdeed33b3ba7772c54b5d094ab53f9b7fd1
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.33"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -152,6 +216,102 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  glob:
+    dependency: transitive
+    description:
+      name: glob
+      sha256: c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.3"
+  hooks:
+    dependency: transitive
+    description:
+      name: hooks
+      sha256: "5d309c86e7ce34cd8e37aa71cb30cb652d3829b900ab145e4d9da564b31d59f7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.6.0"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.2"
+  image_picker:
+    dependency: "direct main"
+    description:
+      name: image_picker
+      sha256: "784210112be18ea55f69d7076e2c656a4e24949fa9e76429fe53af0c0f4fa320"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
+  image_picker_android:
+    dependency: transitive
+    description:
+      name: image_picker_android
+      sha256: "518a16108529fc18657a3e6dde4a043dc465d16596d20ab2abd49a4cac2e703d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.13+13"
+  image_picker_for_web:
+    dependency: transitive
+    description:
+      name: image_picker_for_web
+      sha256: "66257a3191ab360d23a55c8241c91a6e329d31e94efa7be9cf7a212e65850214"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.1"
+  image_picker_ios:
+    dependency: transitive
+    description:
+      name: image_picker_ios
+      sha256: b9c4a438a9ff4f60808c9cf0039b93a42bb6c2211ef6ebb647394b2b3fa84588
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.13+6"
+  image_picker_linux:
+    dependency: transitive
+    description:
+      name: image_picker_linux
+      sha256: "1f81c5f2046b9ab724f85523e4af65be1d47b038160a8c8deed909762c308ed4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
+  image_picker_macos:
+    dependency: transitive
+    description:
+      name: image_picker_macos
+      sha256: "86f0f15a309de7e1a552c12df9ce5b59fe927e71385329355aec4776c6a8ec91"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2+1"
+  image_picker_platform_interface:
+    dependency: transitive
+    description:
+      name: image_picker_platform_interface
+      sha256: "567e056716333a1647c64bb6bd873cff7622233a5c3f694be28a583d4715690c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.11.1"
+  image_picker_windows:
+    dependency: transitive
+    description:
+      name: image_picker_windows
+      sha256: d248c86554a72b5495a31c56f060cf73a41c7ff541689327b1a7dbccc33adfae
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
   intl:
     dependency: "direct main"
     description:
@@ -192,6 +352,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
+  logging:
+    dependency: transitive
+    description:
+      name: logging
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   matcher:
     dependency: transitive
     description:
@@ -216,6 +384,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.17.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
+  native_toolchain_c:
+    dependency: transitive
+    description:
+      name: native_toolchain_c
+      sha256: "89e83885ba09da5fdf2cdacc8002a712ca238c28b7f717910b34bcd27b0d03ac"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.17.4"
   nested:
     dependency: transitive
     description:
@@ -224,6 +408,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  objective_c:
+    dependency: transitive
+    description:
+      name: objective_c
+      sha256: "983c7fa1501f6dcc0cb7af4e42072e9993cb28d73604d25ebf4dab08165d997e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.2.5"
   path:
     dependency: "direct main"
     description:
@@ -232,6 +424,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_provider:
+    dependency: "direct main"
+    description:
+      name: path_provider
+      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.5"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      sha256: f2c65e21139ce2c3dad46922be8272bb5963516045659e71bb16e151c93b580e
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.22"
+  path_provider_foundation:
+    dependency: transitive
+    description:
+      name: path_provider_foundation
+      sha256: "2a376b7d6392d80cd3705782d2caa734ca4727776db0b6ec36ef3f1855197699"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.0"
   path_provider_linux:
     dependency: transitive
     description:
@@ -288,6 +504,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.5+1"
+  pub_semver:
+    dependency: transitive
+    description:
+      name: pub_semver
+      sha256: "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -453,6 +677,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.9.4"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
   vector_math:
     dependency: transitive
     description:
@@ -493,6 +725,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.6.1"
+  yaml:
+    dependency: transitive
+    description:
+      name: yaml
+      sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.3"
 sdks:
   dart: ">=3.10.8 <4.0.0"
-  flutter: ">=3.35.0"
+  flutter: ">=3.38.4"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,10 @@ dependencies:
   
   # Intl for date formatting
   intl: ^0.19.0
+  
+  # Camera and image handling
+  image_picker: ^1.0.7
+  path_provider: ^2.1.2
 
 dev_dependencies:
   flutter_test:

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,9 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <file_selector_windows/file_selector_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  FileSelectorWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FileSelectorWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  file_selector_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
## Summary
Adds progress photo tracking feature with camera integration, gallery view, and photo comparison tools.

## Changes
- **ProgressPhoto model** — stores photo metadata (path, category, date, notes)
- **PhotoService** — handles photo storage and database operations
- **PhotoGalleryScreen** — gallery with category tabs (All/Front/Side/Back)
- **PhotoViewScreen** — full-screen viewing with pinch-to-zoom
- **PhotoCompareScreen** — side-by-side and overlay comparison modes
- **Photos tab** — added to bottom navigation
- **Database v2** — migration adds progress_photos table
- **Permissions** — camera and storage for Android

## Test Instructions
1. Open app → tap **Photos** tab
2. Tap **Add Photo** → choose camera or gallery
3. Select category (Front/Side/Back)
4. Verify photo appears in gallery
5. Tap photo to view full-screen (pinch to zoom)
6. Add 2+ photos → tap **Compare** icon (top right)
7. Test side-by-side view
8. Toggle overlay mode (layers icon) and use slider

Closes #11

🤖 AI-assisted: claude-opus-4-5-thinking (via OpenClaw)