### PR TITLE
feat: Weight tracking with progress photos

### DIFF
--- a/lib/models/progress_photo.dart
+++ b/lib/models/progress_photo.dart
@@ -4,6 +4,7 @@ class ProgressPhoto {
   final String imagePath;
   final String? category; // front, side, back
   final String? notes;
+  final double? weight;
   final DateTime takenAt;
   final DateTime createdAt;
 
@@ -13,6 +14,7 @@ class ProgressPhoto {
     required this.imagePath,
     this.category,
     this.notes,
+    this.weight,
     DateTime? takenAt,
     DateTime? createdAt,
   })  : takenAt = takenAt ?? DateTime.now(),
@@ -25,6 +27,7 @@ class ProgressPhoto {
       'image_path': imagePath,
       'category': category,
       'notes': notes,
+      'weight': weight,
       'taken_at': takenAt.toIso8601String(),
       'created_at': createdAt.toIso8601String(),
     };
@@ -37,6 +40,7 @@ class ProgressPhoto {
       imagePath: map['image_path'] as String,
       category: map['category'] as String?,
       notes: map['notes'] as String?,
+      weight: map['weight'] != null ? (map['weight'] as num).toDouble() : null,
       takenAt: DateTime.parse(map['taken_at'] as String),
       createdAt: DateTime.parse(map['created_at'] as String),
     );
@@ -48,6 +52,7 @@ class ProgressPhoto {
     String? imagePath,
     String? category,
     String? notes,
+    double? weight,
     DateTime? takenAt,
     DateTime? createdAt,
   }) {
@@ -57,6 +62,7 @@ class ProgressPhoto {
       imagePath: imagePath ?? this.imagePath,
       category: category ?? this.category,
       notes: notes ?? this.notes,
+      weight: weight ?? this.weight,
       takenAt: takenAt ?? this.takenAt,
       createdAt: createdAt ?? this.createdAt,
     );

--- a/lib/screens/photos/photo_compare_screen.dart
+++ b/lib/screens/photos/photo_compare_screen.dart
@@ -311,19 +311,44 @@ class _PhotoCompareScreenState extends State<PhotoCompareScreen> {
           bottom: 8,
           left: 8,
           child: IgnorePointer(
-            child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-              decoration: BoxDecoration(
-                color: Colors.black.withValues(alpha: 0.6),
-                borderRadius: BorderRadius.circular(4),
-              ),
-              child: Text(
-                DateFormat('MMM d, y').format(photo.takenAt),
-                style: const TextStyle(
-                  color: Colors.white,
-                  fontSize: 12,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (photo.weight != null)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 4),
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                      decoration: BoxDecoration(
+                        color: Colors.blueAccent.withValues(alpha: 0.8),
+                        borderRadius: BorderRadius.circular(4),
+                      ),
+                      child: Text(
+                        '${photo.weight} kg',
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontWeight: FontWeight.bold,
+                          fontSize: 14,
+                        ),
+                      ),
+                    ),
+                  ),
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                  decoration: BoxDecoration(
+                    color: Colors.black.withValues(alpha: 0.6),
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                  child: Text(
+                    DateFormat('MMM d, y').format(photo.takenAt),
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 12,
+                    ),
+                  ),
                 ),
-              ),
+              ],
             ),
           ),
         ),

--- a/lib/screens/photos/photo_gallery_screen.dart
+++ b/lib/screens/photos/photo_gallery_screen.dart
@@ -80,6 +80,10 @@ class _PhotoGalleryScreenState extends State<PhotoGalleryScreen>
       final userId = appProvider.currentUser?.id;
       if (userId == null) return;
 
+      // Show weight entry dialog (optional)
+      final latestWeight = appProvider.getLatestMeasurement('weight');
+      final weight = await _showWeightDialog(latestWeight?.value);
+
       // Save the photo
       final savedPath = await PhotoService.instance.savePhoto(
         File(image.path),
@@ -90,6 +94,7 @@ class _PhotoGalleryScreenState extends State<PhotoGalleryScreen>
         userId: userId,
         imagePath: savedPath,
         category: category,
+        weight: weight,
       );
 
       await PhotoService.instance.addPhoto(photo);
@@ -124,6 +129,54 @@ class _PhotoGalleryScreenState extends State<PhotoGalleryScreen>
             );
           }).toList(),
         ),
+      ),
+    );
+  }
+
+  Future<double?> _showWeightDialog(double? initialWeight) async {
+    final controller = TextEditingController(
+      text: initialWeight?.toStringAsFixed(1) ?? '',
+    );
+    final appProvider = context.read<AppProvider>();
+    final unit = appProvider.getLatestMeasurement('weight')?.unit ?? 'kg';
+
+    return showDialog<double>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Enter Weight'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text(
+              'Recording your weight with the photo helps track progress better.',
+              style: TextStyle(fontSize: 12, color: Colors.grey),
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              controller: controller,
+              keyboardType: const TextInputType.numberWithOptions(decimal: true),
+              decoration: InputDecoration(
+                labelText: 'Weight ($unit)',
+                border: const OutlineInputBorder(),
+                suffixText: unit,
+              ),
+              autofocus: true,
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Skip'),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              final value = double.tryParse(controller.text);
+              Navigator.pop(context, value);
+            },
+            child: const Text('Save'),
+          ),
+        ],
       ),
     );
   }

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -74,6 +74,7 @@ class DatabaseService {
         image_path TEXT NOT NULL,
         category TEXT,
         notes TEXT,
+        weight REAL,
         taken_at TEXT NOT NULL,
         created_at TEXT NOT NULL,
         FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
@@ -113,6 +114,11 @@ class DatabaseService {
           'CREATE INDEX IF NOT EXISTS idx_progress_photos_user_id ON progress_photos (user_id)');
       await db.execute(
           'CREATE INDEX IF NOT EXISTS idx_progress_photos_taken_at ON progress_photos (taken_at)');
+    }
+
+    if (oldVersion < 3) {
+      // Add weight column to progress_photos
+      await db.execute('ALTER TABLE progress_photos ADD COLUMN weight REAL');
     }
   }
 

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -5,7 +5,7 @@ class AppConstants {
 
   // Database
   static const String dbName = 'body_tracker.db';
-  static const int dbVersion = 2;
+  static const int dbVersion = 3;
 
   // Photo Categories
   static const List<String> photoCategories = ['front', 'side', 'back'];


### PR DESCRIPTION
## Description\nAllows users to record their weight alongside progress photos and displays this weight in the comparison view.\n\n## Changes\n- **Database**: Bumped version to 3 and added \ (REAL) column to \ table.\n- **Models**: Updated \ model to include optional \ field.\n- **UI**: Added a weight entry dialog after photo category selection.\n- **UI**: Display weight labels in the \ for better context during comparison.\n\nCloses #24\n\n🤖 AI-assisted: claude-opus-4-5-thinking (via OpenClaw)