### PR TITLE
fix: unit tests and UserSettings.enabledTabs

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,7 +8,16 @@ import 'services/notification_service.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await NotificationService.instance.initialize();
-  runApp(const MyApp());
+  runApp(
+    ChangeNotifierProvider(
+      create: (_) {
+        final provider = AppProvider();
+        provider.initialize();
+        return provider;
+      },
+      child: const MyApp(),
+    ),
+  );
 }
 
 class MyApp extends StatelessWidget {

--- a/lib/models/user_settings.dart
+++ b/lib/models/user_settings.dart
@@ -3,6 +3,7 @@ class UserSettings {
   final int userId;
   final int reminderIntervalDays;
   final String preferredUnitSystem;
+  final List<String> enabledTabs;
   final DateTime createdAt;
   final DateTime updatedAt;
 
@@ -11,6 +12,7 @@ class UserSettings {
     required this.userId,
     this.reminderIntervalDays = 30,
     this.preferredUnitSystem = 'metric',
+    this.enabledTabs = const ['dashboard', 'measure', 'photos', 'progress', 'sizes', 'profile'],
     DateTime? createdAt,
     DateTime? updatedAt,
   })  : createdAt = createdAt ?? DateTime.now(),
@@ -22,6 +24,7 @@ class UserSettings {
       'user_id': userId,
       'reminder_interval_days': reminderIntervalDays,
       'preferred_unit_system': preferredUnitSystem,
+      'enabled_tabs': enabledTabs.join(','),
       'created_at': createdAt.toIso8601String(),
       'updated_at': updatedAt.toIso8601String(),
     };
@@ -33,6 +36,8 @@ class UserSettings {
       userId: map['user_id'] as int,
       reminderIntervalDays: map['reminder_interval_days'] as int? ?? 30,
       preferredUnitSystem: map['preferred_unit_system'] as String? ?? 'metric',
+      enabledTabs: (map['enabled_tabs'] as String?)?.split(',') ?? 
+          const ['dashboard', 'measure', 'photos', 'progress', 'sizes', 'profile'],
       createdAt: DateTime.parse(map['created_at'] as String),
       updatedAt: DateTime.parse(map['updated_at'] as String),
     );
@@ -43,6 +48,7 @@ class UserSettings {
     int? userId,
     int? reminderIntervalDays,
     String? preferredUnitSystem,
+    List<String>? enabledTabs,
     DateTime? createdAt,
     DateTime? updatedAt,
   }) {
@@ -51,6 +57,7 @@ class UserSettings {
       userId: userId ?? this.userId,
       reminderIntervalDays: reminderIntervalDays ?? this.reminderIntervalDays,
       preferredUnitSystem: preferredUnitSystem ?? this.preferredUnitSystem,
+      enabledTabs: enabledTabs ?? this.enabledTabs,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
     );

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,21 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
+import 'package:provider/provider.dart';
 import 'package:body_tracker/main.dart';
+import 'package:body_tracker/providers/app_provider.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
+  testWidgets('App smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(
+      ChangeNotifierProvider(
+        create: (_) => AppProvider(),
+        child: const MyApp(),
+      ),
+    );
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    // Verify that the splash screen title is present.
+    expect(find.text('Body Tracker'), findsOneWidget);
+    expect(find.byIcon(Icons.straighten), findsOneWidget);
   });
 }


### PR DESCRIPTION
Fixes failing unit tests by adding missing `enabledTabs` field to `UserSettings` model and updating `widget_test.dart` to test the actual app.